### PR TITLE
Add RUSTDOCFLAGS="-D warnings" to treat doc warnings as errors

### DIFF
--- a/docs/migration/v1.0.0.md
+++ b/docs/migration/v1.0.0.md
@@ -1344,6 +1344,8 @@ Add the following steps to your `.github/workflows/rust.yml` file, after the `ca
       - name: Check documentation is valid
         if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/')
         working-directory: src
+        env:
+          RUSTDOCFLAGS: "-D warnings"
         run: cargo doc --workspace --all-features --document-private-items --target ${{ matrix.target }}
 
       - name: Run linter

--- a/templates/library/.github/workflows/rust.yml
+++ b/templates/library/.github/workflows/rust.yml
@@ -159,6 +159,8 @@ jobs:
       - name: Check documentation is valid
         if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/')
         working-directory: src
+        env:
+          RUSTDOCFLAGS: "-D warnings"
         run: cargo doc --workspace --all-features --document-private-items --target {% raw %}${{ matrix.target }}{% endraw %}
 
       - name: Run linter


### PR DESCRIPTION
## Summary
- Adds `RUSTDOCFLAGS="-D warnings"` environment variable to the `cargo doc` CI step, ensuring documentation warnings are treated as errors
- Updates migration guide to reflect the new pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced documentation validation in continuous integration pipelines. Documentation warnings are now treated as build errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->