### PR TITLE
Remove conditional from documentation check for cache effectiveness (v1.1.5)

### DIFF
--- a/docs/migration/about.md
+++ b/docs/migration/about.md
@@ -18,3 +18,4 @@ For information about migrating between template versions, see the following gui
 - **[v1.1.2](v1.1.2.md)** - Add publish dry-run verification with --allow-dirty
 - **[v1.1.3](v1.1.3.md)** - Fix verification scripts, disable YAML format-on-save, split CLI builds
 - **[v1.1.4](v1.1.4.md)** - Simplified AGENTS.md structure, separated formatter CI job, review guidance files
+- **[v1.1.5](v1.1.5.md)** - Remove conditional from documentation check for rustdoc cache effectiveness

--- a/docs/migration/v1.1.5.md
+++ b/docs/migration/v1.1.5.md
@@ -1,0 +1,37 @@
+# Migration to v1.1.5
+
+These are the steps to migrate from `v1.1.4` to `v1.1.5`.
+
+## Remove conditional from documentation check
+
+Removes the `if` guard from the "Check documentation is valid" step so it also
+runs on `main` branch pushes.
+
+**Why:** `Swatinem/rust-cache` saves the build cache on the first push after a
+`Cargo.lock` change. The cache key stays the same until the next lockfile update,
+so subsequent pushes cannot add new artifacts to it.
+
+Previously this step only ran on PRs and tags, meaning the cache (created by a
+`main` push) never included dev-profile artifacts. Every PR recompiled all
+dependencies for `cargo doc` from scratch (~70 s).
+
+Running this step on every push ensures the cache is populated with dev-profile
+artifacts from the start.
+
+### Update `.github/workflows/rust.yml`
+
+```diff
+       - name: Check documentation is valid
+-        if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/')
+         working-directory: src
+         env:
+           RUSTDOCFLAGS: "-D warnings"
+         run: cargo doc --no-deps --workspace --all-features --document-private-items --target ${{ matrix.target }}
+```
+
+## Update the template version marker
+
+```diff
+- reloaded-templates-rust:1.1.4
++ reloaded-templates-rust:1.1.5
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,5 +87,6 @@ nav:
       - To v1.1.2: migration/v1.1.2.md
       - To v1.1.3: migration/v1.1.3.md
       - To v1.1.4: migration/v1.1.4.md
+      - To v1.1.5: migration/v1.1.5.md
   - License: https://reloaded-project.github.io/Reloaded.MkDocsMaterial.Themes.R2/Pages/license.html
   - How to Document: https://reloaded-project.github.io/Reloaded.MkDocsMaterial.Themes.R2/Pages/contributing.html

--- a/templates/general/.github/template-version.txt
+++ b/templates/general/.github/template-version.txt
@@ -1,1 +1,1 @@
-reloaded-templates-rust:1.1.4
+reloaded-templates-rust:1.1.5

--- a/templates/general/.github/workflows/rust.yml
+++ b/templates/general/.github/workflows/rust.yml
@@ -104,7 +104,6 @@ jobs:
 
 {%- endif %}
       - name: Check documentation is valid
-        if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/')
         working-directory: src
         env:
           RUSTDOCFLAGS: "-D warnings"


### PR DESCRIPTION
## Summary

- Removes `if` guard from "Check documentation is valid" step in the template workflow so it also runs on `main` branch pushes
- This ensures `Swatinem/rust-cache` populates the build cache with dev-profile artifacts on the first push after a `Cargo.lock` change, eliminating the ~70 s recompile on every PR (~15-20 s instead)
- Adds v1.1.5 migration guide, nav entry, and version bump